### PR TITLE
Support multiple packages if one matches the project name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
     "[json][jsonc]": {
         "editor.defaultFormatter": "biomejs.biome",
     },
-    "python.testing.pytestArgs": [],
+    "python.testing.pytestArgs": ["--color=yes"],
     "python.testing.pytestEnabled": true,
     "python.terminal.activateEnvironment": false,
     // mirror settings from pyproject-fmt

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 from hatchling.metadata.core import ProjectMetadata
@@ -12,6 +11,9 @@ from hatchling.plugin.manager import PluginManager
 from packaging.metadata import Metadata
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
     from hatch_docstring_description.read_description import ReadDescriptionHook
 
 # TODO(flying-sheep): should hatch support single file modules? "mypkg.py", "src/mypkg.py"
@@ -24,7 +26,7 @@ requires = ['hatchling', 'hatch-docstring-description']
 build-backend = 'hatchling.build'
 
 [project]
-name = 'mypkg'
+name = '{proj_name}'
 version = '1.0'
 requires-python = '>=3.9'
 dynamic = ['description']
@@ -33,30 +35,38 @@ dynamic = ['description']
 """
 
 
-@pytest.fixture(params=["mypkg/__init__.py", "src/mypkg/__init__.py"])
-def basic_project(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
-    project_path = tmp_path / "mypkg"
+def mk_project(root: Path, pkg_loc: Literal[".", "src"], proj_name: str = "mypkg") -> Path:
+    project_path = root / proj_name
     project_path.mkdir()  # error if it exists
-    (project_path / "pyproject.toml").write_text(PYPROJECT_TOML_BASIC)
-    pkg_file_path = project_path / Path(request.param)
+    (project_path / "pyproject.toml").write_text(PYPROJECT_TOML_BASIC.format(proj_name=proj_name))
+    pkg_file_path = project_path / pkg_loc / "mypkg/__init__.py"
     pkg_file_path.parent.mkdir(parents=True, exist_ok=True)
     pkg_file_path.write_text('"""A docstring."""\n')
     return project_path
 
 
-@pytest.fixture
-def pkgs_dir(basic_project: Path) -> Path:
-    return (basic_project / "src") if (basic_project / "src").is_dir() else basic_project
+@pytest.fixture(params=[".", "src"])
+def pkg_loc(request: pytest.FixtureRequest) -> Literal[".", "src"]:
+    return request.param
 
 
 @pytest.fixture
-def multi_pkg_project(basic_project: Path, pkgs_dir: Path) -> Path:
-    prefix = "src/" if pkgs_dir.name == "src" else ""
-    with (basic_project / "pyproject.toml").open("a") as proj_file:
-        proj_file.write(f"[tool.hatch.build.targets.wheel]\npackages = ['{prefix}mypkg', '{prefix}my_other_pkg']\n")
-    (pkg2 := (pkgs_dir / "my_other_pkg")).mkdir()
-    (pkg2 / "__init__.py").write_text('"""A second docstring."""\n')
-    return basic_project
+def basic_project(tmp_path: Path, pkg_loc: Literal[".", "src"]) -> Path:
+    return mk_project(tmp_path, pkg_loc)
+
+
+@pytest.fixture
+def mk_multi_pkg_proj(tmp_path: Path, pkg_loc: Literal[".", "src"]) -> Callable[[str], Path]:
+    def make(proj_name: str) -> Path:
+        proj = mk_project(tmp_path, pkg_loc, proj_name=proj_name)
+        prefix = "src/" if pkg_loc == "src" else ""
+        with (proj / "pyproject.toml").open("a") as proj_file:
+            proj_file.write(f"[tool.hatch.build.targets.wheel]\npackages = ['{prefix}mypkg', '{prefix}my_other_pkg']\n")
+        (pkg2 := (proj / pkg_loc / "my_other_pkg")).mkdir()
+        (pkg2 / "__init__.py").write_text('"""A second docstring."""\n')
+        return proj
+
+    return make
 
 
 def get_hook_cls() -> type[ReadDescriptionHook]:
@@ -97,17 +107,20 @@ def test_e2e(basic_project: Path, tmp_path: Path) -> None:
         distributions=["wheel"],
         isolation=False,
     )
-    with zipfile.ZipFile(out_dir / "mypkg-1.0-py3-none-any.whl", "r") as whl:
-        metadata = Metadata.from_email(whl.open("mypkg-1.0.dist-info/METADATA").read().decode("utf-8"))
+    with (
+        zipfile.ZipFile(out_dir / "mypkg-1.0-py3-none-any.whl", "r") as whl,
+        whl.open("mypkg-1.0.dist-info/METADATA") as metadata_file,
+    ):
+        metadata = Metadata.from_email(metadata_file.read().decode("utf-8"))
     assert metadata.name == "mypkg"
     assert metadata.dynamic is None
     assert metadata.summary == "A docstring."
 
 
 @pytest.mark.xfail(reason="plugin_manager.metadata_hook.get('...') doesn’t work yet")
-def test_explicit(basic_project: Path, pkgs_dir: Path) -> None:
-    prefix = "src/" if pkgs_dir.name == "src" else ""
-    (pkgs_dir / "mypkg" / "core.py").write_text('"""A docstring somewhere else."""\n')
+def test_explicit(basic_project: Path, pkg_loc: Literal[".", "src"]) -> None:
+    prefix = "src/" if pkg_loc == "src" else ""
+    (basic_project / pkg_loc / "mypkg" / "core.py").write_text('"""A docstring somewhere else."""\n')
     with (basic_project / "pyproject.toml").open("a") as proj_file:
         proj_file.write(f"path = ['{prefix}mypkg/core.py']\n")
     hook, metadata = mk_hook(basic_project)
@@ -115,16 +128,24 @@ def test_explicit(basic_project: Path, pkgs_dir: Path) -> None:
     assert metadata["description"] == "A docstring somewhere else."
 
 
+def test_multi_package(mk_multi_pkg_proj: Callable[[str], Path]) -> None:
+    """When one package matches the project name, use that one’s docstring."""
+    hook, metadata = mk_hook(mk_multi_pkg_proj("mypkg"))
+    hook.update(metadata)
+    assert metadata["description"] == "A docstring."
+
+
+def test_multi_package_error(mk_multi_pkg_proj: Callable[[str], Path]) -> None:
+    """If none of the packages match the project name, raise an error."""
+    hook, metadata = mk_hook(mk_multi_pkg_proj("yet_other_name"))
+    with pytest.raises(RuntimeError, match=r"Multiple packages are only supported if one matches the project name"):
+        hook.update(metadata)
+
+
 def test_field_error(basic_project: Path) -> None:
     (basic_project / "pyproject.toml").write_text("[project]\nname = 'mypkg'\n")
     hook, metadata = mk_hook(basic_project)
     with pytest.raises(TypeError, match=r"You need to add 'description'"):
-        hook.update(metadata)
-
-
-def test_multi_package_error(multi_pkg_project: Path) -> None:
-    hook, metadata = mk_hook(multi_pkg_project)
-    with pytest.raises(RuntimeError, match=r"Multiple packages not supported"):
         hook.update(metadata)
 
 


### PR DESCRIPTION
Good to support e.g. PyPI packages containing `mypkg` and `testing.mypkg`