### PR TITLE
Remove `description` key from metadata

### DIFF
--- a/src/hatch_docstring_description/read_description.py
+++ b/src/hatch_docstring_description/read_description.py
@@ -39,6 +39,8 @@ class ReadDescriptionHook(MetadataHookInterface):
             stem = Path(self.root) / pkg
             path = (stem / "__init__.py") if stem.is_dir() else stem.with_name(f"{stem.name}.py")
         metadata["description"] = read_description(path)
+        
+        metadata["dynamic"] = [value for value in metadata["dynamic"] if value != "description"]
 
 
 def _get_pkg(cfg: WheelBuilderConfig) -> PurePath | None:


### PR DESCRIPTION
After processing the description, the key should be removed from the `metadata["dynamic"]` array to prevent errors arising from recalculating the value.

After processing the generated package description, it is no longer a dynamic value. This causes the check for preexisting `description` key to be encountered when building a wheel from an sdist as the sdist contains both the static value and the `Dynamic: Description` in `PKG-INFO`.